### PR TITLE
Close and connection issues seem to be solved for now. 

### DIFF
--- a/subprojects/generator-server/src/main/java/tools/refinery/generator/server/GeneratorServerEndpoint.java
+++ b/subprojects/generator-server/src/main/java/tools/refinery/generator/server/GeneratorServerEndpoint.java
@@ -88,6 +88,7 @@ public class GeneratorServerEndpoint {
 	public void onWebSocketError(Throwable cause)
 	{
 		// The WebSocket endpoint failed.
+		LOG.error("Websocket Error - The cause:", cause);
 
 		// You may log the error.
 		cause.printStackTrace();
@@ -99,9 +100,8 @@ public class GeneratorServerEndpoint {
 	@OnWebSocketClose
 	public void onWebSocketClose(int statusCode, String reason)
 	{
-		// The WebSocket endpoint has been closed.
-
-		// You may dispose resources.
+		LOG.info("WebSocket close! Status:{} - Reason(UUID):{}", statusCode, reason);
+		ModelGeneratorDispatcher.getInstance().disconnect(UUID.fromString(reason));
 		//disposeResources();
 	}
 }

--- a/subprojects/generator-server/src/main/java/tools/refinery/generator/server/ModelGeneratorDispatcher.java
+++ b/subprojects/generator-server/src/main/java/tools/refinery/generator/server/ModelGeneratorDispatcher.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 
 /**
 * Singleton class for dispatching the requests on separate threads
- * TODO
  * Make this a singleton, so that no other instances can be made
  * ModelGenerator should be running on separate threads, once started
  * Status updates should be sent through via the session
@@ -45,6 +44,12 @@ public class ModelGeneratorDispatcher {
 	public void cancelGenerationRequest(UUID uuid) {
 		ModelGeneratorExecutor threadOfExecution = threadPool.get(uuid);
 		threadOfExecution.cancel();
+	}
+
+	public void disconnect(UUID uuid) {
+		ModelGeneratorExecutor threadOfExecution = threadPool.get(uuid);
+		threadPool.remove(uuid);
+		threadOfExecution.disconnect();
 	}
 
 	private ModelGeneratorDispatcher() {

--- a/subprojects/generator-server/src/main/java/tools/refinery/generator/server/ModelGeneratorExecutor.java
+++ b/subprojects/generator-server/src/main/java/tools/refinery/generator/server/ModelGeneratorExecutor.java
@@ -118,6 +118,10 @@ public class ModelGeneratorExecutor extends Thread {
 		session.sendText(partialInterpretationString, Callback.NOOP);
 	}
 
+	public void disconnect() {
+		this.session.close();
+	}
+
 	@Override
 	public void run() {
 		if (!cancelled) {

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/GeneratorWebSocketEndpoint.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/GeneratorWebSocketEndpoint.java
@@ -1,0 +1,229 @@
+package tools.refinery.language.web.generator;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.*;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.refinery.language.web.semantics.metadata.NodeMetadata;
+import tools.refinery.language.web.semantics.metadata.RelationMetadata;
+import tools.refinery.language.web.semantics.metadata.RelationMetadataGson;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+@WebSocket
+public class GeneratorWebSocketEndpoint {
+	private static final Logger LOG = LoggerFactory.getLogger(GeneratorWebSocketEndpoint.class);
+	private LinkedBlockingQueue<ModelGenerationResult> responseQueue = new LinkedBlockingQueue<>();
+	private LinkedBlockingQueue<List<NodeMetadata>> nodesMetaDataQueue = new LinkedBlockingQueue<>();
+	private LinkedBlockingQueue<List<RelationMetadata>> relationsMetadataQueue = new LinkedBlockingQueue<>();
+	private LinkedBlockingQueue<JsonObject> partialInterpretaitonQueue = new LinkedBlockingQueue<>();
+	private URI uri;
+	private UUID uuidOfWorker;
+	private WebSocketClient client;
+	private Session session;
+	private long timeoutSec;
+	private boolean finished;
+
+	private void getGeneratorUri(){
+		String portStr = System.getenv("REFINERY_GENERATOR_WS_PORT");
+		boolean portIsSet = portStr != null && !portStr.isEmpty();
+		int port;
+		if (portIsSet){
+			port = Integer.parseInt(portStr);
+		} else {
+			port = 1314; //The default port
+		}
+
+		String host = System.getenv("REFINERY_GENERATOR_WS_HOST");
+		if (host == null || host.isEmpty()){
+			System.out.println("NO HOSTNAME SET (REFINERY_GENERATOR_WS_HOST)... localhost set");
+			host = "localhost";
+		}
+
+		uri = URI.create("ws://" + host + ":" + port);
+		System.out.println("URI:" + uri);
+	}
+
+	public GeneratorWebSocketEndpoint() throws Exception {
+		getGeneratorUri();
+		client = new WebSocketClient();
+		finished = false;
+	}
+
+	public void setTimeoutSec(long timeoutSec) {
+		this.timeoutSec = timeoutSec;
+	}
+
+	public void setUuidOfWorker(UUID uuid) {
+		this.uuidOfWorker = uuid;
+	}
+
+	private void addResultToQueue(ModelGenerationResult result) throws InterruptedException {
+		if (responseQueue != null) {
+			responseQueue.offer(result, timeoutSec, TimeUnit.SECONDS);
+		}
+	}
+
+	public ModelGenerationResult getResult() throws InterruptedException {
+		return responseQueue.poll(timeoutSec, TimeUnit.SECONDS);
+	}
+
+	public JsonObject getPartialInterpretaiton() throws InterruptedException {
+		return partialInterpretaitonQueue.poll(timeoutSec, TimeUnit.SECONDS);
+	}
+
+	public List<NodeMetadata> getNodesMetaData() throws InterruptedException {
+		return nodesMetaDataQueue.poll(timeoutSec, TimeUnit.SECONDS);
+	}
+
+	public List<RelationMetadata> getRelationsMetaData() throws InterruptedException {
+		return relationsMetadataQueue.poll(timeoutSec, TimeUnit.SECONDS);
+	}
+
+	public void connect() throws Exception {
+		ClientUpgradeRequest customRequest = new ClientUpgradeRequest();
+		customRequest.setHeader("UUID", uuidOfWorker.toString());
+		System.out.println("Before client start");
+		client.start();
+		System.out.println("SEND:" + this.uri);
+		System.out.println("Before connect");
+		LOG.info("Connecting to '" + this.uri + "' with UUID:" + this.uuidOfWorker);
+		Future<Session> fut = client.connect(this, uri, customRequest);
+		System.out.println("After connect");
+		session = fut.get(timeoutSec, TimeUnit.SECONDS);
+	}
+
+	public void sendGenerationRequest(String problemText, int randomSeed) throws Exception {
+		if (finished)
+			return;
+		if (session == null || !session.isOpen()) {
+			connect();
+		}
+
+		var type = "generationRequest";
+		var uuid = this.uuidOfWorker.toString();
+		JsonObject jsonToSend = new JsonObject();
+		jsonToSend.addProperty("type", type);
+		jsonToSend.addProperty("uuid", uuid);
+		JsonObject generationData = new JsonObject();
+		generationData.addProperty("randomSeed", randomSeed);
+		generationData.addProperty("problem", problemText);
+		jsonToSend.addProperty("generationDetails", generationData.toString());
+
+		session.sendText(jsonToSend.toString(), Callback.NOOP);
+	}
+
+	public void sendCancelRequest() throws Exception {
+		System.out.println("Trying to cancel UUID:" + uuidOfWorker);
+		if (finished)
+			return;
+		var type = "cancelRequest";
+		var uuid = this.uuidOfWorker.toString();
+		JsonObject jsonToSend = new JsonObject();
+		jsonToSend.addProperty("type", type);
+		jsonToSend.addProperty("uuid", uuid);
+
+		session.sendText(jsonToSend.toString(), Callback.NOOP);
+	}
+
+	@OnWebSocketClose
+	public void onClose(int statusCode, String reason)
+	{
+		LOG.info("WebSocket Close for UUID:{}: Status:{} - Reason:{}",uuidOfWorker, statusCode,reason);
+		//This is not needed, as the Client (ModelRemoteGenerationWorker) initiates the
+		/*
+		try {
+			//this.close();
+		} catch (Exception e) {
+			LOG.error("Couldn't close connection");
+			throw new RuntimeException(e);
+		}
+		 */
+	}
+
+	@OnWebSocketOpen
+	public void onOpen(Session session)
+	{
+		LOG.info("WebSocket Open Session:{}", session);
+	}
+
+	@OnWebSocketError
+	public void onError(Throwable cause)
+	{
+		LOG.warn("WebSocket Error",cause);
+	}
+
+	@OnWebSocketMessage
+	public void onText(String message) throws InterruptedException {
+		LOG.info("Text Message [{}]",message);
+		System.out.println("Client onText:\n" + message);
+
+		//Parsing the received message
+		JsonObject jsonMessage = JsonParser.parseString(message).getAsJsonObject();
+		var type = jsonMessage.get("type").getAsString();
+
+		if (type.equals("result")){
+			var resultMessage = jsonMessage.get("message").getAsString();
+			var modelGenerationResult = new ModelGenerationStatusResult(uuidOfWorker, resultMessage);
+			responseQueue.offer(modelGenerationResult);
+		}
+
+		if (type.equals("error")){
+			var resultMessage = jsonMessage.get("message").getAsString();
+			var modelGenerationResult = new ModelGenerationErrorResult(uuidOfWorker, resultMessage);
+			responseQueue.offer(modelGenerationResult);
+		}
+
+		if (type.equals("nodesMetadata")){
+			var nodesMetaDataArray = jsonMessage.get("object").getAsJsonArray();
+			Type listType = new TypeToken<List<NodeMetadata>>(){}.getType();
+			List<NodeMetadata> nodesMetaDataObject = new Gson().fromJson(nodesMetaDataArray, listType);
+			nodesMetaDataQueue.offer(nodesMetaDataObject);
+		}
+
+		if (type.equals("relationsMetadata")){
+			var relationsMetadataArray = jsonMessage.get("object").getAsJsonArray();
+			Type listType = new TypeToken<List<RelationMetadata>>(){}.getType();
+			List<RelationMetadata> relationsMetadataObject =  RelationMetadataGson.createGson().fromJson(relationsMetadataArray, listType);
+			relationsMetadataQueue.offer(relationsMetadataObject);
+		}
+
+		if (type.equals("partialInterpretation")){
+			var partialInterpretaitonString = jsonMessage.get("object").getAsString();
+			var partialInterpretaiton = JsonParser.parseString(partialInterpretaitonString).getAsJsonObject();
+			var partialInterpretaitonObject = new Gson().fromJson(partialInterpretaiton, JsonObject.class);
+			System.out.println(partialInterpretaitonObject);
+			partialInterpretaitonQueue.offer(partialInterpretaitonObject);
+		}
+	}
+
+	public void close() throws Exception {
+		session.close(1000, uuidOfWorker.toString(), Callback.from( () -> {
+			try {
+				client.stop();
+				client = null;
+			} catch (Exception e) {
+				LOG.error("Couldn't stop client!");
+				throw new RuntimeException(e.getMessage());
+			}
+		}, this::closeFailed));
+
+	}
+
+	public void closeFailed(Throwable x) {
+		LOG.error("closeFailed - couldn't stop websocket client for some reason", x);
+	}
+}

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/IGenerationWorker.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/IGenerationWorker.java
@@ -14,7 +14,7 @@ public interface IGenerationWorker {
 
 	public void startTimeout();
 
-	public ModelGenerationResult doRun() throws IOException;
+	public ModelGenerationResult doRun() throws Exception;
 
 	public void cancel();
 

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelGenerationService.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelGenerationService.java
@@ -59,8 +59,6 @@ public class ModelGenerationService {
 	}
 
 	private ModelGenerationStartedResult generateModelRemote(PushWebDocumentAccess document, int randomSeed){
-		//TODO create a remote worker as a client, for the generator server
-		// TODO send data of modelgeneration request to the server
 		return document.modify(new CancelableUnitOfWork<>() {
 			@Override
 			public ModelGenerationStartedResult exec(IXtextWebDocument state, CancelIndicator cancelIndicator) {

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelGenerationService.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelGenerationService.java
@@ -22,7 +22,7 @@ public class ModelGenerationService {
 	public static final String SERVICE_NAME = "modelGeneration";
 	public static final String MODEL_GENERATION_EXECUTOR = "modelGeneration";
 	public static final String MODEL_GENERATION_TIMEOUT_EXECUTOR = "modelGenerationTimeout";
-	public static final boolean USE_GENERATOR_SERVER = true;
+	public static  boolean USE_GENERATOR_SERVER = true;
 
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
@@ -37,6 +37,9 @@ public class ModelGenerationService {
 
 	public ModelGenerationService() {
 		timeoutSec = SemanticsService.getTimeout("REFINERY_MODEL_GENERATION_TIMEOUT_SEC").orElse(600L);
+		String useGenServer = System.getenv("USE_GENERATOR_SERVER");
+		if (useGenServer != null)
+			USE_GENERATOR_SERVER = Boolean.getBoolean(useGenServer);
 	}
 
 	private ModelGenerationStartedResult generateModelLocal(PushWebDocumentAccess document, int randomSeed){
@@ -66,8 +69,8 @@ public class ModelGenerationService {
 				var worker = remoteWorkerProvider.get();
 				worker.setState(pushState, randomSeed, timeoutSec);
 				var manager = pushState.getModelGenerationManager();
-				worker.start();
 				boolean canceled = manager.setActiveModelGenerationWorker(worker, cancelIndicator);
+				worker.start();
 				if (canceled) {
 					worker.cancel();
 					operationCanceledManager.throwOperationCanceledException();

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelRemoteGenerationWorker.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelRemoteGenerationWorker.java
@@ -32,214 +32,6 @@ import java.util.UUID;
 import java.util.concurrent.*;
 
 public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable {
-	@WebSocket
-	public class GeneratorWebSocketEndpoint {
-		private static final Logger LOG = LoggerFactory.getLogger(GeneratorWebSocketEndpoint.class);
-		private LinkedBlockingQueue<ModelGenerationResult> responseQueue = new LinkedBlockingQueue<>();
-		private LinkedBlockingQueue<List<NodeMetadata>> nodesMetaDataQueue = new LinkedBlockingQueue<>();
-		private LinkedBlockingQueue<List<RelationMetadata>> relationsMetadataQueue = new LinkedBlockingQueue<>();
-		private LinkedBlockingQueue<JsonObject> partialInterpretaitonQueue = new LinkedBlockingQueue<>();
-		private URI uri;
-		private UUID uuidOfWorker;
-		private final WebSocketClient client;
-		private Session session;
-		private long timeoutSec;
-
-		private void getGeneratorUri(){
-			String portStr = System.getenv("REFINERY_GENERATOR_WS_PORT");
-			boolean portIsSet = portStr != null && !portStr.isEmpty();
-			int port;
-			if (portIsSet){
-				port = Integer.parseInt(portStr);
-			} else {
-				port = 1314; //The default port
-			}
-
-			String host = System.getenv("REFINERY_GENERATOR_WS_HOST");
-			if (host == null || host.isEmpty()){
-				System.out.println("NO HOSTNAME SET (REFINERY_GENERATOR_WS_HOST)... localhost set");
-				host = "localhost";
-			}
-
-			uri = URI.create("ws://" + host + ":" + port);
-			System.out.println("URI:" + uri);
-		}
-
-		public GeneratorWebSocketEndpoint() throws Exception {
-			getGeneratorUri();
-			client = new WebSocketClient();
-		}
-
-		public void setTimeoutSec(long timeoutSec) {
-			this.timeoutSec = timeoutSec;
-		}
-
-		public void setUuidOfWorker(UUID uuid) {
-			this.uuidOfWorker = uuid;
-		}
-
-		private void addResultToQueue(ModelGenerationResult result) throws InterruptedException {
-			if (responseQueue != null) {
-				responseQueue.offer(result, timeoutSec, TimeUnit.SECONDS);
-			}
-		}
-
-		public ModelGenerationResult getResult() throws InterruptedException {
-			return responseQueue.poll(timeoutSec, TimeUnit.SECONDS);
-		}
-
-		public JsonObject getPartialInterpretaiton() throws InterruptedException {
-			return partialInterpretaitonQueue.poll(timeoutSec, TimeUnit.SECONDS);
-		}
-
-		public List<NodeMetadata> getNodesMetaData() throws InterruptedException {
-			return nodesMetaDataQueue.poll(timeoutSec, TimeUnit.SECONDS);
-		}
-
-		public List<RelationMetadata> getRelationsMetaData() throws InterruptedException {
-			return relationsMetadataQueue.poll(timeoutSec, TimeUnit.SECONDS);
-		}
-
-		public void connect() throws Exception {
-			ClientUpgradeRequest customRequest = new ClientUpgradeRequest();
-			customRequest.setHeader("UUID", uuidOfWorker.toString());
-			System.out.println("Before client start");
-			client.start();
-			System.out.println("SEND:" + this.uri);
-			System.out.println("Before connect");
-			LOG.info("Connecting to '" + this.uri + "' with UUID:" + this.uuidOfWorker);
-			Future<Session> fut = client.connect(this, uri, customRequest);
-			System.out.println("After connect");
-			session = fut.get(timeoutSec, TimeUnit.SECONDS);
-		}
-
-		public void sendGenerationRequest(String problemText, int randomSeed) throws Exception {
-			if (session == null || !session.isOpen()) {
-				connect();
-			}
-
-			var type = "generationRequest";
-			var uuid = this.uuidOfWorker.toString();
-			JsonObject jsonToSend = new JsonObject();
-			jsonToSend.addProperty("type", type);
-			jsonToSend.addProperty("uuid", uuid);
-			JsonObject generationData = new JsonObject();
-			generationData.addProperty("randomSeed", randomSeed);
-			generationData.addProperty("problem", problemText);
-			jsonToSend.addProperty("generationDetails", generationData.toString());
-
-			session.sendText(jsonToSend.toString(), Callback.NOOP);
-		}
-
-		public void sendCancelRequest() throws Exception {
-			if (session == null || !session.isOpen())
-				connect();
-
-			var type = "cancelRequest";
-			var uuid = this.uuidOfWorker.toString();
-			JsonObject jsonToSend = new JsonObject();
-			jsonToSend.addProperty("type", type);
-			jsonToSend.addProperty("uuid", uuid);
-
-			session.sendText(jsonToSend.toString(), Callback.NOOP);
-		}
-
-		@OnWebSocketClose
-		public void onClose(int statusCode, String reason)
-		{
-			LOG.info("WebSocket Close for UUID:{}: Status:{} - Reason:{}",uuidOfWorker, statusCode,reason);
-			try {
-				//this.close();
-			} catch (Exception e) {
-				LOG.error("Couldn't close connection");
-				throw new RuntimeException(e);
-			}
-		}
-
-		@OnWebSocketOpen
-		public void onOpen(Session session)
-		{
-			LOG.info("WebSocket Open Session:{}", session);
-		}
-
-		@OnWebSocketError
-		public void onError(Throwable cause)
-		{
-			LOG.warn("WebSocket Error",cause);
-		}
-
-		@OnWebSocketMessage
-		public void onText(String message) throws InterruptedException {
-			LOG.info("Text Message [{}]",message);
-			System.out.println("Client onText:\n" + message);
-
-			//Parsing the received message
-			JsonObject jsonMessage = JsonParser.parseString(message).getAsJsonObject();
-			var type = jsonMessage.get("type").getAsString();
-
-			if (type.equals("result")){
-				var resultMessage = jsonMessage.get("message").getAsString();
-				var modelGenerationResult = new ModelGenerationStatusResult(uuidOfWorker, resultMessage);
-				responseQueue.offer(modelGenerationResult);
-			}
-
-			if (type.equals("error")){
-				var resultMessage = jsonMessage.get("message").getAsString();
-				var modelGenerationResult = new ModelGenerationErrorResult(uuidOfWorker, resultMessage);
-				responseQueue.offer(modelGenerationResult);
-			}
-
-			if (type.equals("nodesMetadata")){
-				var nodesMetaDataArray = jsonMessage.get("object").getAsJsonArray();
-				Type listType = new TypeToken<List<NodeMetadata>>(){}.getType();
-				List<NodeMetadata> nodesMetaDataObject = new Gson().fromJson(nodesMetaDataArray, listType);
-				nodesMetaDataQueue.offer(nodesMetaDataObject);
-			}
-
-			if (type.equals("relationsMetadata")){
-				var relationsMetadataArray = jsonMessage.get("object").getAsJsonArray();
-				Type listType = new TypeToken<List<RelationMetadata>>(){}.getType();
-				List<RelationMetadata> relationsMetadataObject =  RelationMetadataGson.createGson().fromJson(relationsMetadataArray, listType);
-				relationsMetadataQueue.offer(relationsMetadataObject);
-			}
-
-			if (type.equals("partialInterpretation")){
-				var partialInterpretaitonString = jsonMessage.get("object").getAsString();
-				var partialInterpretaiton = JsonParser.parseString(partialInterpretaitonString).getAsJsonObject();
-				var partialInterpretaitonObject = new Gson().fromJson(partialInterpretaiton, JsonObject.class);
-				System.out.println(partialInterpretaitonObject);
-				partialInterpretaitonQueue.offer(partialInterpretaitonObject);
-			}
-		}
-
-		public void close() throws Exception {
-			boolean canBeClosed = false;
-			while (!canBeClosed)
-			{
-				System.out.println(relationsMetadataQueue.size());
-				System.out.println(responseQueue.size());
-				System.out.println(nodesMetaDataQueue.size());
-				System.out.println(partialInterpretaitonQueue.size());
-				canBeClosed = relationsMetadataQueue.isEmpty() &&
-								nodesMetaDataQueue.isEmpty() &&
-								partialInterpretaitonQueue.isEmpty() &&
-								responseQueue.isEmpty();
-			}
-			session.close(1000, uuidOfWorker.toString(), Callback.from( () -> {
-				try {
-					client.stop();
-				} catch (Exception e) {
-					LOG.error("Couldn't stop client!");
-					throw new RuntimeException(e.getMessage());
-				}
-			}, this::closeFailed));
-
-		}
-
-		public void closeFailed(Throwable x) {
-			LOG.error("closeFailed - couldn't stop websocket client for some reason", x);
-		}
-	}
 	private static final Logger LOG = LoggerFactory.getLogger(ModelRemoteGenerationWorker.class);
 	private final UUID uuid = UUID.randomUUID();
 	private PushWebDocument state;
@@ -265,7 +57,6 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 	private ScheduledFuture<?> timeoutFuture;
 	private GeneratorWebSocketEndpoint client;
 	private ModelGenerationErrorResult errorResult;
-	private boolean finished = false;
 
 	private final CancellationToken cancellationToken = () -> {
 		if (cancelled || Thread.interrupted()) {
@@ -281,6 +72,13 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 	}
 
 	public ModelRemoteGenerationWorker(){
+		try {
+			setupClient();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			LOG.error("Couldn't setup client!");
+		}
 	}
 
 	@Inject
@@ -321,7 +119,7 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 		this.randomSeed = randomSeed;
 		this.timeoutSec = timeoutSec;
 		this.text = state.getText();
-		//client.setTimeoutSec(timeoutSec);
+		client.setTimeoutSec(timeoutSec);
 	}
 
 	@Override
@@ -348,6 +146,7 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 
 	@Override
 	public ModelGenerationResult doRun() throws Exception {
+		System.out.println("doRun()");
 		cancellationToken.checkCancelled();
 		try {
 			client.sendGenerationRequest(text, randomSeed);
@@ -387,17 +186,7 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 
 	@Override
 	public void run(){
-		if (finished) {
-			LOG.info("Finished value: {}", finished);
-			return;
-		}
-		try {
-			setupClient();
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			LOG.error("Couldn't setup client!");
-		}
+		System.out.println("run()");
 		startTimeout();
 		notifyResult(new ModelGenerationStatusResult(uuid, "Initializing model generator"));
 		ModelGenerationResult result;
@@ -419,7 +208,7 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 		}
 		System.out.println(result);
 		notifyResult(result);
-		finished = true;
+		//Thread.currentThread().interrupt();
 	}
 
 	@Override
@@ -432,7 +221,8 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 		synchronized (lockObject) {
 			LOG.trace("Cancelling model generation: {}", uuid);
 			try {
-				client.sendCancelRequest();
+				if (this.client != null)
+					client.sendCancelRequest();
 			} catch (Exception e) {
 				LOG.debug(e.getMessage(), e);
 				System.out.println("Could not cancel model generation of uuid: " + uuid);

--- a/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelRemoteGenerationWorker.java
+++ b/subprojects/language-web/src/main/java/tools/refinery/language/web/generator/ModelRemoteGenerationWorker.java
@@ -147,6 +147,13 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 		public void onClose(int statusCode, String reason)
 		{
 			LOG.info("WebSocket Close: {} - {}",statusCode,reason);
+			/*try {
+				this.close();
+			} catch (Exception e) {
+				LOG.error("Couldn't close connection");
+				throw new RuntimeException(e);
+			}
+			 */
 		}
 
 		@OnWebSocketOpen
@@ -206,6 +213,14 @@ public class ModelRemoteGenerationWorker implements IGenerationWorker, Runnable 
 		}
 
 		public void close() throws Exception {
+			boolean canBeClosed = false;
+			while(!canBeClosed)
+			{
+				canBeClosed = relationsMetadataQueue.isEmpty() &&
+								nodesMetaDataQueue.isEmpty() &&
+								partialInterpretaitonQueue.isEmpty() &&
+								responseQueue.isEmpty();
+			}
 			session.close();
 			client.stop();
 		}


### PR DESCRIPTION
Currently, whenever a new generation request is made, the old generation request is trying to send out a cancelGeneration request, based on the fact that it thinks that the request timed out.

For now, it has been solved with a janky mechanism (GeneratorWebSocketEndpoint with "finished" field of instance). It works, but the olds threads seem to not stop / something with cancelTokens might be wrong.